### PR TITLE
lk2nd: device: msm8952: Add Motorola Moto G5 (cedric)

### DIFF
--- a/lk2nd/device/dts/msm8952/motorola.dtsi
+++ b/lk2nd/device/dts/msm8952/motorola.dtsi
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include <lk2nd.dtsi>
+
+&lk2nd {
+	motorola-cedric {
+		model = "Motorola Moto G5";
+		compatible = "qcom,msm8937-cedric", "qcom,msm8937-moto", "qcom,msm8937";
+	};
+};

--- a/lk2nd/device/dts/msm8952/msm8937-motorola-cedric.dts
+++ b/lk2nd/device/dts/msm8952/msm8937-motorola-cedric.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include <skeleton64.dtsi>
+#include "xiaomi.dtsi"
+
+/ {
+	qcom,msm-id = <QCOM_ID_MSM8937 66 0 0x10000>;
+};

--- a/lk2nd/device/dts/msm8952/msm8937-motorola-cedric.dts
+++ b/lk2nd/device/dts/msm8952/msm8937-motorola-cedric.dts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 #include <skeleton64.dtsi>
-#include "xiaomi.dtsi"
+#include "motorola.dtsi"
 
 / {
 	qcom,msm-id = <QCOM_ID_MSM8937 66 0 0x10000>;

--- a/lk2nd/device/dts/msm8952/rules.mk
+++ b/lk2nd/device/dts/msm8952/rules.mk
@@ -3,3 +3,4 @@ LOCAL_DIR := $(GET_LOCAL_DIR)
 
 ADTBS += \
 	$(LOCAL_DIR)/msm8940-xiaomi-santoni.dtb \
+	$(LOCAL_DIR)/msm8937-motorola-cedric.dtb


### PR DESCRIPTION
Moto G5 is a budget phone under the Motorola brand (owned by Lenovo) It has either 2 or 3GB RAM, 16GB of eMMC and a MSM8937 SoC. Needs to be built with the LK2ND_ADTBS=msm8937-motorola-cedric.dtb option when running make, otherwise the bootloader refuses to boot it.